### PR TITLE
refactor overlay to not shadow packages

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -13,20 +13,29 @@ let
 
   tdlib = super.tdlib.overrideAttrs (_:
     (getAttributesFromJSONFile ../repos/unstable/tdlib.json));
-  telegaOverride = old: {
-      buildInputs = (remove super.tdlib old.buildInputs) ++ [ tdlib ];
-  } // (getAttributesFromJSONFile ../repos/unstable/telega.json);
 
   stable-tdlib = super.tdlib.overrideAttrs (_:
     (getAttributesFromJSONFile ../repos/stable/tdlib.json));
-  telegaStableOverride = old: {
-      buildInputs = (remove super.tdlib old.buildInputs) ++ [ stable-tdlib ];
-  } // (getAttributesFromJSONFile ../repos/stable/telega.json);
 in {
   emacsPackagesFor = emacs: (
-    (super.emacsPackagesFor emacs).overrideScope (eself: esuper: {
-      melpaPackages.telega = esuper.melpaPackages.telega.overrideAttrs telegaOverride;
-      melpaStablePackages.telega = esuper.melpaStablePackages.telega.overrideAttrs telegaStableOverride;
-      telega = esuper.telega.overrideAttrs telegaStableOverride;
+    (super.emacsPackagesFor emacs).overrideScope (eself: esuper:
+    let
+        telegaOverride = old: {
+          buildInputs = (remove super.tdlib old.buildInputs) ++ [ tdlib ];
+          packageRequires = old.packageRequires or [ ] ++ [ eself.rainbow-identifiers ];
+        } // (getAttributesFromJSONFile ../repos/unstable/telega.json);
+        telegaStableOverride = old: {
+          buildInputs = (remove super.tdlib old.buildInputs) ++ [ stable-tdlib ];
+        } // (getAttributesFromJSONFile ../repos/stable/telega.json);
+    in
+    {
+        melpaPackages = esuper.melpaPackages // {
+            telega = esuper.melpaPackages.telega.overrideAttrs telegaOverride;
+        };
+        melpaStablePackages = esuper.melpaStablePackages // {
+            telega = esuper.melpaStablePackages.telega.overrideAttrs telegaStableOverride;
+        };
+        # Stable package is too outdated
+        telega = eself.melpaPackages.telega;
     }));
 }


### PR DESCRIPTION
Originally, applying this overlay lead to missing packages in melpaPackages or melpaStablePackages. This refactoring extends the set of original packages in melpa 